### PR TITLE
Add Docker-based Postgres setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # cron-as-a-service
 A cron application where users can define a job and a schedule for it to run on.
+
+## Infrastructure
+
+A PostgreSQL server is provided via Docker. Use `docker-compose` from the
+`infrastructure` directory to start it:
+
+```bash
+cd infrastructure
+docker-compose up -d
+```
+
+The server listens on port `5432` and uses the following default credentials:
+- **user**: `cron`
+- **password**: `cronpass`
+- **database**: `cron_db`

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  postgres:
+    build: ./postgres
+    container_name: cron-postgres
+    restart: always
+    environment:
+      POSTGRES_USER: cron
+      POSTGRES_PASSWORD: cronpass
+      POSTGRES_DB: cron_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/infrastructure/postgres/Dockerfile
+++ b/infrastructure/postgres/Dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:15-alpine
+
+ENV POSTGRES_USER=cron
+ENV POSTGRES_PASSWORD=cronpass
+ENV POSTGRES_DB=cron_db
+
+# Expose the postgres port
+EXPOSE 5432


### PR DESCRIPTION
## Summary
- add infrastructure folder with Docker configs
- document how to start the Postgres container

## Testing
- `docker-compose -f infrastructure/docker-compose.yml config` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868051da95c832485d463868e339413